### PR TITLE
fix(language): ucase overrides

### DIFF
--- a/syntaxes/solidity.tmLanguage.json
+++ b/syntaxes/solidity.tmLanguage.json
@@ -1181,5 +1181,5 @@
     }
   },
   "scopeName": "source.solidity",
-  "uuid": "18e064f3-32b1-44de-ac9e-10f0607d7b84"
+  "uuid": "aada0596-7358-46f0-9ea1-6f9e986ce966"
 }


### PR DESCRIPTION
reduce the false positives by fixing regex. this overrides values for `constant.numeric.decimal.solidity`